### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raspi-ruxpin-frontend",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raspi-ruxpin-frontend",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "bootstrap": "^5.3.0",
         "vue": "^3.5.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspi-ruxpin-frontend",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "private": true,
   "engines": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "raspi-ruxpin"
-version = "2.0.0"
+version = "2.1.0"
 description = "Modern animatronic bear control system with FastAPI and Vue 3"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -919,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "raspi-ruxpin"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Bumps version to 2.1.0 in pyproject.toml, uv.lock, frontend/package.json, and frontend/package-lock.json
- No functional changes since 2.0.0 beyond CI/Dependabot setup and pre-existing debt cleanup (#4)

## Test plan
- [x] `uv run ruff check backend/`, `uv run mypy backend/`, `uv run pytest` all pass