### PR TITLE
Bump version to 2.1.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raspi-ruxpin-frontend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raspi-ruxpin-frontend",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "bootstrap": "^5.3.0",
         "vue": "^3.5.39"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspi-ruxpin-frontend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "private": true,
   "engines": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "raspi-ruxpin"
-version = "2.1.0"
+version = "2.1.1"
 description = "Modern animatronic bear control system with FastAPI and Vue 3"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -919,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "raspi-ruxpin"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Bumps version to 2.1.1 (patch) in pyproject.toml, uv.lock, frontend/package.json, and frontend/package-lock.json
- Follows dependency updates merged via #5, #6, #7, #8, #10, #11, #12 (GitHub Actions bumps, Vue/tsconfig bump, and a Vite 8 major upgrade requiring a manualChunks fix for the new Rolldown bundler)
- #9 (TypeScript 7) intentionally deferred - vue-tsc can't resolve TS7's compiler yet, left open with an explanatory comment

## Test plan
- [x] `uv run ruff check backend/`, `uv run mypy backend/`, `uv run pytest` all pass
- [x] `npm run build` (Vite 8 + Rolldown) and `npm run type-check` pass